### PR TITLE
Ablation tests showed keep everything as is.

### DIFF
--- a/src/syn_grid/config/configs.yaml
+++ b/src/syn_grid/config/configs.yaml
@@ -125,11 +125,11 @@ agent:
     # - check_env: set to true if you wanna control your changes in the environment didn't break anything obvious
     alg: "PPO"
     agent_steps: "307200"
-    id_tag: 'vector_termination_exp'
+    id_tag: 'vector_markovian_ablations'
     save_folder: 'experiments'
     seed: 3
     human_control: false
-    training: false
+    training: true
     check_env: false
 
   # Pick algorithm to train or evaluate
@@ -141,13 +141,13 @@ agent:
     # - render_mode (null or "human"): null is default, change to human if you want visual feedback for debugging
     # - timesteps: number of timesteps per iteration (a checkpoint is saved after this many steps)
     # - iterations: total number of training iterations
-    continue_training: true
+    continue_training: false
     monitor_output: true
     tensorboard_output: true
     model_output: true
     render_mode: null
-    timesteps: 40000
-    iterations: 5
+    timesteps: 100000
+    iterations: 3
 
   eval_agent_conf:
     # - num_eval_episodes: how many episodes to evaluate


### PR DESCRIPTION
Thing to note is that having orb timer in the obs made convergence slower. I ran a 100k scenario with de-spawnable tier orbs, max tier 2. However, to confirm this it would be a good thing to test this on a more complex scenario. But since I'm not using the timer for the thesis that can wait.