### PR TITLE
Fixed reward scaling.

### DIFF
--- a/src/syn_grid/config/configs.yaml
+++ b/src/syn_grid/config/configs.yaml
@@ -15,15 +15,19 @@ world:
   grid_world_conf:
     # - number of rows and columns
     # - single_chain_mode: if true only one of each orb will be created and spawned at once, if collected in order episode terminates with a reward, else just truncation
+    # - max_tier_scoring (used in tier_orb_conf, must be active in single_chain_mode): if true, reward is only given if max tier is reached
+    # - termination_on_max_tier: terminate the episode as max tier is reached
+    # - de_spawn_tiers: decides if tiers should de-spawn just as the non tier orbs
     # - max_tier: this is the highest tier that orbs can reach in this environment
     # - max active orbs: number of max active orbs on grid
-    # - de_spawn_tiers: decides if tiers should de-spawn just as the non tier orbs
     grid_rows: &grid_rows 5
     grid_cols: &grid_cols 5
-    single_chain_mode: &single_chain_mode true
-    max_tier: &max_tier 4
-    max_active_orbs: &max_active_orbs 3
+    single_chain_mode: &single_chain_mode false
+    max_tier_scoring: &max_tier_scoring false
+    termination_on_max_tier: &termination_on_max_tier false
     de_spawn_tiers: &de_spawn_tiers false
+    max_tier: &max_tier 2
+    max_active_orbs: &max_active_orbs 3
 
   renderer_conf:
     # - grid_rows / grid_cols (set in grid_world_conf): used to calculate display size and layout
@@ -41,24 +45,20 @@ world:
     # - grid_rows / grid_cols (set in grid_world_conf): defines the grid the droid can move in
     # - starting_score: initial score of the droid
     # - step_penalty: the cost of moving around for the agent
-    # - tier_consumption_penalty: (only applicable if step_wise_scoring is true)punishment for consuming tier orbs in the wrong order
-    # - reward_multiplier: multiplier applied to rewards when threshold scoring in tier_orb_conf is activated
-    # - termination_on_max_tier: terminate the episode as max tier is reached
+    # - tier_consumption_penalty (passed to digestion engine): (only applicable if step_wise_scoring is true) punishment for consuming tier orbs in the wrong order
+    # - reward_multiplier (passed to digestion engine): multiplier applied to rewards when threshold scoring in tier_orb_conf is activated, a sensible default is 1.0, then experiment if reward magnitudes get's to large for higher max tiers
     grid_rows: *grid_rows
     grid_cols: *grid_cols
     starting_score: 50
     step_penalty: &step_penalty -1.0
     tier_consumption_penalty: *step_penalty
-    reward_multiplier: 0.5
-    termination_on_max_tier: &termination_on_max_tier true
+    reward_multiplier: 1.0
 
 
   orb_factory_conf:
     # - grid_rows / grid_cols (set in grid_world_conf): used to set orbs life span
     # - max_active_orbs (set in grid_world_conf): max active orbs on grid
-    # - max_tier: this is the highest tier that orbs can reach in this environment
-    # - termination_on_max_tier (set in droid_conf): don't change this, it determine if single chain mode is possible
-    # - max_tier_scoring (also used in tier_orb_conf, must be active in single_chain_mode): if true, reward is only given if max tier is reached
+    # - max_tier (set in grid_world_conf): this is the highest tier that orbs can reach in this environment
     # - single_chain_mode (set in grid_world_conf): if true only one of each orb will be created and spawned at once, if collected in order episode terminates with a reward, else just termination
     # - each orb type can be enabled/disabled
     # - weight defines relative spawn frequency when multiple orbs are active
@@ -66,8 +66,6 @@ world:
     grid_cols: *grid_cols
     max_active_orbs: *max_active_orbs
     max_tier: *max_tier
-    termination_on_max_tier: *termination_on_max_tier
-    max_tier_scoring: &max_tier_scoring true
     single_chain_mode: *single_chain_mode
     types:
       negative:
@@ -87,16 +85,16 @@ world:
     # - linear_reward_growth: if true, reward scales linearly instead of exponentially
     # - step_wise_scoring: if true, reward is given per correctly consumed tier instead of on chain break
     # - threshold_scoring: if true, partial reward is given if the chain breaks or an accumulated reward if max tier is reached
-    # - max_tier_scoring (set in orb_factory_conf): if true, reward is only given if max tier is reached
+    # - max_tier_scoring (set in grid_world_conf): if true, reward is only given if max tier is reached
     # - growth_factor: multiplier applied per tier increase if linear_reward_growth is false
     # - base_reward: starting reward value at tier 0
     # - cool_down: number of steps before the orb can be reused
     linear_reward_growth: false
     step_wise_scoring: false
-    threshold_scoring: false
+    threshold_scoring: true
     max_tier_scoring: *max_tier_scoring
-    growth_factor: 1.5
-    base_reward: 3
+    growth_factor: 2.0
+    base_reward: 3.0
     cool_down: 7
 
 ###########################
@@ -107,7 +105,7 @@ obs:
   observation_handler:
     # - perception: decides type and how much information to pack into the agents observation. Hard, medium and easy are the options
     # - max_steps: number of steps in an episode until truncated
-    perception: "vector_fully_pomdp"
+    perception: "vector_markovian"
     max_steps: &max_steps 100
 
   perception:
@@ -143,12 +141,12 @@ agent:
     # - training: set to false to evaluate the agent
     # - check_env: set to true if you wanna control your changes in the environment didn't break anything obvious
     alg: "PPO"
-    agent_steps: "10014720"
-    id_tag: 'max_tier_breakdown'
-    save_folder: 'experiments/tier_break'
+    agent_steps: "301056"
+    id_tag: null
+    save_folder: 'experiments/just_checking'
     seed: 3
-    human_control: true
-    training: true
+    human_control: false
+    training: false
     check_env: false
 
   # Pick algorithm to train or evaluate
@@ -160,16 +158,16 @@ agent:
     # - render_mode (null or "human"): null is default, change to human if you want visual feedback for debugging
     # - timesteps: number of timesteps per iteration (a checkpoint is saved after this many steps)
     # - iterations: total number of training iterations
-    continue_training: true
+    continue_training: false
     monitor_output: true
     tensorboard_output: true
     model_output: true
     render_mode: null
-    timesteps: 1000000
-    iterations: 10
+    timesteps: 100000
+    iterations: 3
 
   eval_agent_conf:
     # - num_eval_episodes: how many episodes to evaluate
     # - render_mode (null or "human"): set to null if you don't want visual feedback during evaluation
-    num_eval_episodes: 20
+    num_eval_episodes: 300
     render_mode: null

--- a/src/syn_grid/config/models.py
+++ b/src/syn_grid/config/models.py
@@ -18,9 +18,11 @@ class GridWorldConf(BaseModel, frozen=True):
     grid_rows: int
     grid_cols: int
     single_chain_mode: bool
+    max_tier_scoring: bool
+    termination_on_max_tier: bool
+    de_spawn_tiers: bool
     max_tier: int
     max_active_orbs: int
-    de_spawn_tiers: bool
 
     @model_validator(mode="after")
     def validate_config(self):
@@ -29,8 +31,19 @@ class GridWorldConf(BaseModel, frozen=True):
         if self.max_active_orbs <= 0:
             raise ValueError("max_active_orbs should be larger than 0")
         if self.single_chain_mode:
-            if self.de_spawn_tiers:
-                raise ValueError('de_spawn_tiers must be false when single_chain_mode is true')
+            if self.max_tier >= (self.grid_rows * self.grid_cols):
+                raise ValueError(
+                    "max_tier can't be higher than number of cells in the grid, there will be no space for orbs"
+                )
+            if not self.max_tier_scoring:
+                raise ValueError(
+                    f"Single_chain_mode requires max_tier_scoring to be true"
+                )
+            if self.de_spawn_tiers or not self.termination_on_max_tier:
+                raise ValueError(
+                    "de_spawn_tiers must be false and termination_on_max_tier must be true when single_chain_mode is true"
+                )
+
             object.__setattr__(self, "max_active_orbs", self.max_tier)
 
         return self
@@ -63,7 +76,6 @@ class DroidConf(BaseModel, frozen=True):
     step_penalty: float
     tier_consumption_penalty: float
     reward_multiplier: float
-    termination_on_max_tier: bool
 
     @model_validator(mode="after")
     def validate_config(self):
@@ -90,31 +102,13 @@ class OrbFactoryConf(BaseModel, frozen=True):
     grid_cols: int
     max_active_orbs: int
     max_tier: int
-    termination_on_max_tier: bool
-    max_tier_scoring: bool
     single_chain_mode: bool
     types: TypesConf
 
     @model_validator(mode="after")
     def validate_config(self):
-        single_chain_requirements = [
-            self.termination_on_max_tier,
-            self.max_tier_scoring,
-        ]
-
         if self.max_tier <= 0:
             raise ValueError("max_tier should be larger than 0")
-        if self.single_chain_mode:
-            if self.max_tier >= (self.grid_rows * self.grid_cols):
-                raise ValueError(
-                    "max_tier can't be higher than number of cells in the grid, there will be no space for orbs"
-                )
-            if not all(single_chain_requirements):
-                raise ValueError(
-                    f"Single_chain_mode requires:"
-                    f"\ntermination_on_max_tier to be enabled in DroidConf"
-                    f"\nand max_tier_scoring enabled in OrbFactoryConf"
-                )
 
         return self
 

--- a/src/syn_grid/config/test_configs.yaml
+++ b/src/syn_grid/config/test_configs.yaml
@@ -22,15 +22,19 @@ world:
   grid_world_conf:
     # - number of rows and columns
     # - single_chain_mode: if true only one of each orb will be created and spawned at once, if collected in order episode terminates with a reward, else just truncation
+    # - max_tier_scoring (used in tier_orb_conf, must be active in single_chain_mode): if true, reward is only given if max tier is reached
+    # - termination_on_max_tier: terminate the episode as max tier is reached
+    # - de_spawn_tiers: decides if tiers should de-spawn just as the non tier orbs
     # - max_tier: this is the highest tier that orbs can reach in this environment
     # - max active orbs: number of max active orbs on grid
-    # - de_spawn_tiers: decides if tiers should de-spawn just as the non tier orbs
     grid_rows: &grid_rows 5
     grid_cols: &grid_cols 5
     single_chain_mode: &single_chain_mode false
-    max_tier: &max_tier 3
-    max_active_orbs: &max_active_orbs 3
+    max_tier_scoring: &max_tier_scoring false
+    termination_on_max_tier: &termination_on_max_tier false
     de_spawn_tiers: &de_spawn_tiers true
+    max_tier: &max_tier 4
+    max_active_orbs: &max_active_orbs 3
 
   renderer_conf:
     # - grid_rows / grid_cols (set in grid_world_conf): used to calculate display size and layout
@@ -48,23 +52,19 @@ world:
     # - grid_rows / grid_cols (set in grid_world_conf): defines the grid the droid can move in
     # - starting_score: initial score of the droid
     # - step_penalty: the cost of moving around for the agent
-    # - tier_consumption_penalty: (only applicable if step_wise_scoring is true)punishment for consuming tier orbs in the wrong order
-    # - reward_multiplier: multiplier applied to rewards when threshold scoring in tier_orb_conf is activated
-    # - termination_on_max_tier: terminate the episode as max tier is reached
+    # - tier_consumption_penalty (passed to digestion engine): (only applicable if step_wise_scoring is true) punishment for consuming tier orbs in the wrong order
+    # - reward_multiplier (passed to digestion engine): multiplier applied to rewards when threshold scoring in tier_orb_conf is activated, a sensible default is 1.0, then experiment if reward magnitudes get's to large for higher max tiers
     grid_rows: *grid_rows
     grid_cols: *grid_cols
     starting_score: 30
     step_penalty: &step_penalty -1.0
     tier_consumption_penalty: *step_penalty
-    reward_multiplier: 0.5
-    termination_on_max_tier: &termination_on_max_tier false
+    reward_multiplier: 1.0
 
   orb_factory_conf:
     # - grid_rows / grid_cols (set in grid_world_conf): used to set orbs life span
     # - max_active_orbs (set in grid_world_conf): max active orbs on grid
-    # - max_tier: this is the highest tier that orbs can reach in this environment
-    # - termination_on_max_tier (set in droid_conf): don't change this, it determine if single chain mode is possible
-    # - max_tier_scoring (also used in tier_orb_conf, must be active in single_chain_mode): if true, reward is only given if max tier is reached
+    # - max_tier (set in grid_world_conf): this is the highest tier that orbs can reach in this environment
     # - single_chain_mode (set in grid_world_conf): if true only one of each orb will be created and spawned at once, if collected in order episode terminates with a reward, else just termination
     # - each orb type can be enabled/disabled
     # - weight defines relative spawn frequency when multiple orbs are active
@@ -72,8 +72,6 @@ world:
     grid_cols: *grid_cols
     max_active_orbs: *max_active_orbs
     max_tier: *max_tier
-    termination_on_max_tier: *termination_on_max_tier
-    max_tier_scoring: &max_tier_scoring false
     single_chain_mode: *single_chain_mode
     types:
       negative:
@@ -93,7 +91,7 @@ world:
     # - linear_reward_growth: if true, reward scales linearly instead of exponentially
     # - step_wise_scoring: if true, reward is given per correctly consumed tier instead of on chain break
     # - threshold_scoring: if true, partial reward is given if the chain breaks or an accumulated reward if max tier is reached
-    # - max_tier_scoring (set in orb_factory_conf): if true, reward is only given if max tier is reached
+    # - max_tier_scoring (set in grid_world_conf): if true, reward is only given if max tier is reached
     # - growth_factor: multiplier applied per tier increase if linear_reward_growth is false
     # - base_reward: starting reward value at tier 0
     # - cool_down: number of steps before the orb can be reused

--- a/src/syn_grid/core/droid/digestion_engine.py
+++ b/src/syn_grid/core/droid/digestion_engine.py
@@ -12,15 +12,9 @@ class DigestionEngine:
     #        Init       #
     # ================= #
 
-    def __init__(
-        self,
-        tier_consumption_penalty: float,
-        reward_multiplier: float,
-        termination_on_max_tier: bool,
-    ):
+    def __init__(self, tier_consumption_penalty: float, reward_multiplier: float):
         self._tier_consumption_penalty = tier_consumption_penalty
         self._reward_multiplier = reward_multiplier
-        self.termination_on_max_tier = termination_on_max_tier
 
     def reset(self):
         self.chained_tiers = self._NO_CHAIN
@@ -61,6 +55,8 @@ class DigestionEngine:
             if consumed_orb.max_tier_scoring:
                 return self._max_tier_scoring(consumed_orb)
 
+            raise ValueError("The scoring type for this orb isn't implemented")
+
         # Non-tier orbs: always return base reward and resets reward state
         self.reset()
         return consumed_orb.REWARD
@@ -75,11 +71,14 @@ class DigestionEngine:
         current_tier = consumed_orb.META.TIER
 
         if self.chained_tiers == current_tier - 1 or current_tier == 1:
-            self.chained_tiers = (
-                current_tier
-                if current_tier != consumed_orb.max_tier
-                else self._NO_CHAIN
-            )
+            if current_tier == consumed_orb.max_tier:
+                self.chained_tiers = self._NO_CHAIN
+                self.max_tier_reached = (
+                    True  # impactful only in terminate_on_max_tier scenarios
+                )
+            else:
+                self.chained_tiers = current_tier
+
             return consumed_orb.REWARD
 
         self.chained_tiers = self._NO_CHAIN
@@ -99,6 +98,9 @@ class DigestionEngine:
 
             # If we reached max tier, reset the chain and return the bonus
             self.chained_tiers = self._NO_CHAIN
+            self.max_tier_reached = (
+                True  # impactful only in terminate_on_max_tier scenarios
+            )
             return self._flush_rewards()[1] + scaled_reward
 
         # Handel pending reward if chain is broken,
@@ -113,7 +115,7 @@ class DigestionEngine:
                 return 0.0
 
             self.chained_tiers = self._NO_CHAIN
-            self.max_tier_reached = True
+            self.max_tier_reached = True  # essential for this scoring type
             return consumed_orb.REWARD
 
         self.chained_tiers = (
@@ -123,10 +125,6 @@ class DigestionEngine:
         return 0.0
 
     # === Scoring helpers === #
-
-    def _set_pending_rewards(self, scaled_reward: float):
-        self._pending_reward = scaled_reward
-        self._max_reward_bonus += self._pending_reward
 
     def _handle_chain_break(self, current_tier: int, scaled_reward: float) -> float:
         """
@@ -158,6 +156,10 @@ class DigestionEngine:
             pending_reward = self._flush_rewards()[0]
 
         return pending_reward
+
+    def _set_pending_rewards(self, scaled_reward: float):
+        self._pending_reward = scaled_reward
+        self._max_reward_bonus += self._pending_reward
 
     def _flush_rewards(self) -> tuple[float, float]:
         temp_rew = self._pending_reward

--- a/src/syn_grid/core/droid/synergy_droid.py
+++ b/src/syn_grid/core/droid/synergy_droid.py
@@ -21,9 +21,7 @@ class SynergyDroid:
         self._conf: Final[DroidConf] = conf
         self._single_chain_mode = single_chain_mode
         self.digestion_engine: Final[DigestionEngine] = DigestionEngine(
-            conf.tier_consumption_penalty,
-            conf.reward_multiplier,
-            conf.termination_on_max_tier,
+            conf.tier_consumption_penalty, conf.reward_multiplier
         )
 
     def reset(self) -> None:

--- a/src/syn_grid/gymnasium/environment.py
+++ b/src/syn_grid/gymnasium/environment.py
@@ -135,25 +135,41 @@ class SYNGridEnv(gym.Env):
         return hud_data
 
     def _check_episode_end(self) -> tuple[bool, bool]:
+        """
+        Determine whether the episode should terminate or be truncated.
+
+        Returns:
+            (terminated, truncated): Both booleans. Terminated indicates natural end
+            (success/failure). Truncated indicates early cut due to step limit in
+            single_chain_mode (not a failure).
+        """
+
         terminated = False
         truncated = False
 
         if self.world.droid.score <= 0:
+            # always terminate when agent is out of score
             terminated = True
         elif self._observation_handler.steps_left <= 0:
+            # if we run single_chain_mode, treat out of step as truncation, since we are not
+            # measuring survival as a true goal, otherwise terminate — because the agent did good
             if self.world._conf.single_chain_mode:
                 truncated = True
             else:
                 terminated = True
         elif (
-            self.world.droid.digestion_engine.termination_on_max_tier
+            self.world._conf.termination_on_max_tier
             and self.world.droid.digestion_engine.max_tier_reached
         ):
+            # if we run any termination_on_max_tier scenario, we terminate whenever the first max
+            # tier is reached
             terminated = True
         elif self.world._conf.single_chain_mode and (
             len(self.world._active_orbs) == 0
             and not self.world.droid.digestion_engine.max_tier_reached
         ):
+            # in single_chain_mode and if all orbs are consumed but in wrong order, terminate the
+            # episode
             terminated = True
 
         return terminated, truncated

--- a/src/syn_grid/runners/agent_runners/sb3/stateless_ppo.py
+++ b/src/syn_grid/runners/agent_runners/sb3/stateless_ppo.py
@@ -64,11 +64,11 @@ class StatelessPPO(BaseSB3Runner[PPO]):
                     episode_rewards.append(info[0].get("reward"))
                     step_count += 1
 
-                    print(
-                        f'Episode {i}, reward: {episode_rewards[-1]}, droid score: {info[0]["score"]}, sum of rewards: {np.sum(episode_rewards)}'
-                    )
+                    # print(
+                    #     f'Episode {i}, reward: {episode_rewards[-1]}, droid score: {info[0]["score"]}, sum of rewards: {np.sum(episode_rewards)}'
+                    # )
                     if done_arr[0]:
-                        print()
+                        # print()
                         break
 
                 episode_lengths.append(step_count)
@@ -82,7 +82,7 @@ class StatelessPPO(BaseSB3Runner[PPO]):
         avg_length = sum(episode_lengths) / len(episode_lengths)
         sum_rew = sum(r for r in all_rewards)
         avg_rew = sum_rew / self._eval_conf.num_eval_episodes
-        max_tier_reached = sum(1 for r in all_rewards if r == 9)
+        max_tier_reached = sum(1 for r in all_rewards if r == 14)
         avg_max_tier = max_tier_reached / self._eval_conf.num_eval_episodes
         num_tier_out_of_order = sum(1 for r in all_rewards if r == -2)
         average_tier_out_of_order = (

--- a/src/syn_grid/runners/human_runner/human_runner.py
+++ b/src/syn_grid/runners/human_runner/human_runner.py
@@ -37,7 +37,7 @@ class HumanRunner:
                 self._render()
 
                 if (terminated or truncated) or (
-                    self._world.droid.digestion_engine.termination_on_max_tier
+                    self._world._conf.termination_on_max_tier
                     and self._world.droid.digestion_engine.max_tier_reached
                 ):
                     break

--- a/tests/core/droid/test_digestion_engine.py
+++ b/tests/core/droid/test_digestion_engine.py
@@ -34,7 +34,7 @@ class TestDigestionEngine:
     @pytest.fixture
     def digestion_engine(self) -> DigestionEngine:
         BaseOrb.set_life_span(5, 5)
-        d = DigestionEngine(-1.0, 0.5, False)
+        d = DigestionEngine(-1.0, 1.0)
         d.reset()
         return d
 
@@ -115,12 +115,14 @@ class TestDigestionEngine:
         assert digestion_engine.digest(orb) == 0
         assert digestion_engine.chained_tiers == orb.META.TIER
 
-    def test_delayed_scoring_max_tier_consumption_rewards_and_resets_chain(
+    def test_threshold_scoring_max_tier_consumption_rewards_and_resets_chain(
         self, digestion_engine: DigestionEngine
     ):
         max_orb = TierOrb(self._MAX_TIER, get_test_config().world.tier_orb_conf)
-        # set correct scoring type
+        # set correct scoring type and max tier
         max_orb.step_wise_scoring = False
+        max_orb.threshold_scoring = True
+        max_orb.max_tier = self._MAX_TIER
 
         # prep the "chain" by giving it a tier value 1 lower than max_orb
         digestion_engine.chained_tiers = max_orb.META.TIER - 1


### PR DESCRIPTION
I used a multiplier in my new threshold scoring type scenario and dwarfed scores by 0.5. This destroyed the exploring signal a little bit so the model didn't converge as fast and with a little less optimal behavior. So I set it to 1.0 as a default and noted that it can be modified if magnitudes in reward gets to big.

It might just add unnecessary computation though. So keep this in mind running experiments later, might remove it if fps takes to much of a bang (every millistep is valuable when we run a 10M training sesch :D).